### PR TITLE
Auto continutation and event names

### DIFF
--- a/src/application/Orchestration.Contract/ContinuationBase.cs
+++ b/src/application/Orchestration.Contract/ContinuationBase.cs
@@ -5,15 +5,11 @@ namespace Super.Paula.Application.Orchestration
 {
     public record ContinuationBase
     {
-        public ContinuationBase(string name)
+        public ContinuationBase()
         {
             Id = Guid.NewGuid();
-            Name = name;
             (CreationDate, CreationTime) = DateTimeNumbers.GlobalNow;
         }
-
-        [JsonInclude]
-        public string Name { get; private init; }
 
         [JsonInclude]
         public Guid Id { get; private init; }

--- a/src/application/Orchestration.Contract/ContinuationRegistration.cs
+++ b/src/application/Orchestration.Contract/ContinuationRegistration.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 namespace Super.Paula.Application.Orchestration
 {
     public record ContinuationRegistration(
-        string ContinuationName,
         Type ContinuationType,
         Type ContinuationHandlerType,
         IContinuationHandler ContinuationHandler,

--- a/src/application/Orchestration.Contract/EventBase.cs
+++ b/src/application/Orchestration.Contract/EventBase.cs
@@ -5,15 +5,11 @@ namespace Super.Paula.Application.Orchestration
 {
     public record EventBase
     {
-        public EventBase(string name)
+        public EventBase()
         {
             Id = Guid.NewGuid();
-            Name = name;
             (CreationDate, CreationTime) = DateTimeNumbers.GlobalNow;
         }
-
-        [JsonInclude]
-        public string Name { get; private init; }
 
         [JsonInclude]
         public Guid Id { get; private init; }

--- a/src/application/Orchestration.Contract/EventRegistration.cs
+++ b/src/application/Orchestration.Contract/EventRegistration.cs
@@ -2,5 +2,5 @@
 
 namespace Super.Paula.Application.Orchestration
 {
-    public record EventRegistration( string EventName, Type EventType);
+    public record EventRegistration(Type EventType);
 }

--- a/src/application/Orchestration.Contract/IContinuationRegistry.cs
+++ b/src/application/Orchestration.Contract/IContinuationRegistry.cs
@@ -9,10 +9,11 @@ namespace Super.Paula.Application.Orchestration
 
         Type? GetContinuationType(string continuationName);
 
-        void Register<TContinuation, THandler>(string continuationName)
+        void Register<TContinuation, THandler>()
             where TContinuation : ContinuationBase
             where THandler : IContinuationHandler<TContinuation>;
 
-        void Unregister(string continuationName);
+        void Unregister<TContinuation>()
+            where TContinuation : ContinuationBase;
     }
 }

--- a/src/application/Orchestration.Contract/IEventTypeRegistry.cs
+++ b/src/application/Orchestration.Contract/IEventTypeRegistry.cs
@@ -6,9 +6,10 @@ namespace Super.Paula.Application.Orchestration
     {
         Type? GetEventType(string eventName);
 
-        void Register<TEvent>(string eventName)
+        void Register<TEvent>()
             where TEvent : EventBase;
 
-        void Unregister(string eventName);
+        void Unregister<TEvent>()
+            where TEvent : EventBase;
     }
 }

--- a/src/application/Orchestration/Continuator.cs
+++ b/src/application/Orchestration/Continuator.cs
@@ -39,8 +39,9 @@ namespace Super.Paula.Application.Orchestration
 
         public async Task ExecuteAsync<TContinuation>(TContinuation continuation, ClaimsPrincipal? user = null)
             where TContinuation : ContinuationBase
-        { 
-            var continuationCall = _continuationRegistry.GetContinuationHandlerCall(continuation.Name);
+        {
+            var continuationName = TypeNameConverter.ToKebabCase(typeof(TContinuation));
+            var continuationCall = _continuationRegistry.GetContinuationHandlerCall(continuationName);
 
             if (continuationCall == null)
             {

--- a/src/application/Orchestration/InMemoryEventTypeRegistry.cs
+++ b/src/application/Orchestration/InMemoryEventTypeRegistry.cs
@@ -28,13 +28,13 @@ namespace Super.Paula.Application.Orchestration
             return exists ? eventRegistration?.EventType : null;
         }
 
-        public void Register<TEvent>(string eventName)
+        public void Register<TEvent>()
             where TEvent : EventBase
         {
             var eventType = typeof(TEvent);
+            var eventName = TypeNameConverter.ToKebabCase(eventType);
 
             var eventRegistration = new EventRegistration(
-                eventName,
                 typeof(TEvent));
 
             _eventRegistrations.AddOrUpdate(eventName, eventRegistration,
@@ -45,8 +45,12 @@ namespace Super.Paula.Application.Orchestration
                 });
         }
 
-        public void Unregister(string eventName)
+        public void Unregister<TEvent>()
+            where TEvent : EventBase
         {
+            var eventType = typeof(TEvent);
+            var eventName = TypeNameConverter.ToKebabCase(eventType);
+
             var removed = _eventRegistrations.TryRemove(eventName, out _);
 
             if (!removed)

--- a/src/application/Orchestration/PersistentContinuationStorage.cs
+++ b/src/application/Orchestration/PersistentContinuationStorage.cs
@@ -29,7 +29,7 @@ namespace Super.Paula.Application.Orchestration
         {
             var entity = new Continuation
             {
-                Name = continuation.Name,
+                Name = TypeNameConverter.ToKebabCase(continuation.GetType()),
                 CreationTime = continuation.CreationTime,
                 CreationDate = continuation.CreationDate,
                 Id = continuation.Id.ToString(),

--- a/src/application/Orchestration/PersistentEventProcessingStorage.cs
+++ b/src/application/Orchestration/PersistentEventProcessingStorage.cs
@@ -27,9 +27,12 @@ namespace Super.Paula.Application.Orchestration
 
         public async ValueTask AddAsync(string subscriberName, EventBase @event, ClaimsPrincipal user)
         {
+            var eventType = @event.GetType();
+            var eventName = TypeNameConverter.ToKebabCase(eventType);
+
             var entity = new EventProcessing
             {
-                Name = @event.Name,
+                Name = eventName,
                 Subscriber = subscriberName,
                 CreationTime = @event.CreationTime,
                 CreationDate = @event.CreationDate,

--- a/src/application/Orchestration/PersistentEventStorage.cs
+++ b/src/application/Orchestration/PersistentEventStorage.cs
@@ -27,9 +27,12 @@ namespace Super.Paula.Application.Orchestration
 
         public async ValueTask AddAsync(EventBase @event, ClaimsPrincipal user)
         {
+            var eventType = @event.GetType();
+            var eventName = TypeNameConverter.ToKebabCase(eventType);
+
             var entity = new Event
             {
-                Name = @event.Name,
+                Name = eventName,
                 CreationTime = @event.CreationTime,
                 CreationDate = @event.CreationDate,
                 Id = @event.Id.ToString(),

--- a/src/application/Shared.Tests/TypeNameConverterTests.cs
+++ b/src/application/Shared.Tests/TypeNameConverterTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Super.Paula
+{
+    public class TypeNameConverterTests
+    {
+        [Theory]
+        [InlineData(typeof(TypeNameConverterTests), "type-name-converter-tests")]
+        [InlineData(typeof(UInt32), "u-int-32")]
+        public void ToKebabCase_ReturnsKebabCase_ForTypeNameConverterTests(Type type, string kebabCase)
+        {
+            // Act
+            var result = TypeNameConverter.ToKebabCase(type);
+
+            // Assert
+            result.Should().Be(kebabCase);
+        }
+    }
+}

--- a/src/application/Shared/TypeNameConverter.cs
+++ b/src/application/Shared/TypeNameConverter.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Super.Paula
+{
+    public static class TypeNameConverter
+    {
+        public static string ToKebabCase(Type type)
+        {
+            var pascalCase = type.Name;
+            var kebabCase = new StringBuilder();
+
+            for (var i = 0; i < pascalCase.Length; i++)
+            {
+                // if current char is already lowercase
+                if (char.IsLower(pascalCase[i])) 
+                {
+                    kebabCase.Append(pascalCase[i]);
+                    continue;
+                }
+
+                // if current char is the first char
+                if (i == 0) 
+                {
+                    kebabCase.Append(char.ToLower(pascalCase[i]));
+                    continue;
+                }
+
+                // if current char is a number and the previous is not
+                if (char.IsDigit(pascalCase[i]) && !char.IsDigit(pascalCase[i - 1])) 
+                {
+                    kebabCase.Append('-');
+                    kebabCase.Append(pascalCase[i]);
+                    continue;
+                }
+
+                // if current char is a number and previous is
+                if (char.IsDigit(pascalCase[i])) 
+                {
+                    kebabCase.Append(pascalCase[i]);
+                    continue;
+                }
+
+                // if current char is upper and previous char is lower
+                if (char.IsLower(pascalCase[i - 1]))
+                {
+                    kebabCase.Append('-');
+                    kebabCase.Append(char.ToLower(pascalCase[i]));
+                    continue;
+                }
+
+                // if current char is upper and next char doesn't exist or is upper
+                if (i + 1 == pascalCase.Length || char.IsUpper(pascalCase[i + 1])) 
+                {
+                    kebabCase.Append(char.ToLower(pascalCase[i]));
+                    continue;
+                }
+
+                kebabCase.Append('-');
+                kebabCase.Append(char.ToLower(pascalCase[i]));
+            }
+
+            return kebabCase.ToString();
+        }
+    }
+}

--- a/src/application/Transport.Contract/Administration/Continuation/ActivateIdentityInspectorContinuation.cs
+++ b/src/application/Transport.Contract/Administration/Continuation/ActivateIdentityInspectorContinuation.cs
@@ -20,5 +20,5 @@ namespace Super.Paula.Application.Administration.Continuation
         [KebabCase]
         string Inspector)
         
-        : ContinuationBase("activate-identity-inspector");
+        : ContinuationBase();
 }

--- a/src/application/Transport.Contract/Administration/Continuation/CreateIdentityInspectorContinuation.cs
+++ b/src/application/Transport.Contract/Administration/Continuation/CreateIdentityInspectorContinuation.cs
@@ -22,5 +22,5 @@ namespace Super.Paula.Application.Administration.Continuation
 
         bool Activated) 
         
-        : ContinuationBase("create-identity-inspector");
+        : ContinuationBase();
 }

--- a/src/application/Transport.Contract/Administration/Continuation/CreateInspectorContinuation.cs
+++ b/src/application/Transport.Contract/Administration/Continuation/CreateInspectorContinuation.cs
@@ -27,5 +27,5 @@ namespace Super.Paula.Application.Administration.Continuation
 
         bool Activated) 
         
-        : ContinuationBase("create-inspector");
+        : ContinuationBase();
 }

--- a/src/application/Transport.Contract/Administration/Continuation/DeactivateIdentityInspectorContinuation.cs
+++ b/src/application/Transport.Contract/Administration/Continuation/DeactivateIdentityInspectorContinuation.cs
@@ -20,5 +20,5 @@ namespace Super.Paula.Application.Administration.Continuation
         [KebabCase]
         string Inspector) 
         
-        : ContinuationBase("deactivate-identity-inspector");
+        : ContinuationBase();
 }

--- a/src/application/Transport.Contract/Administration/Continuation/DeleteIdentityInspectorContinuation.cs
+++ b/src/application/Transport.Contract/Administration/Continuation/DeleteIdentityInspectorContinuation.cs
@@ -20,5 +20,5 @@ namespace Super.Paula.Application.Administration.Continuation
         [KebabCase]
         string Inspector) 
         
-        : ContinuationBase("delete-identity-inspector");
+        : ContinuationBase();
 }

--- a/src/application/Transport.Contract/Administration/Events/InspectorBusinessObjectEvent.cs
+++ b/src/application/Transport.Contract/Administration/Events/InspectorBusinessObjectEvent.cs
@@ -28,6 +28,6 @@ namespace Super.Paula.Application.Administration.Events
 
         bool OldAuditScheduleDelayed)
 
-        : EventBase("event-inspector-business-object");
+        : EventBase();
 
 }

--- a/src/application/Transport.Contract/Administration/Events/OrganizationCreationEvent.cs
+++ b/src/application/Transport.Contract/Administration/Events/OrganizationCreationEvent.cs
@@ -17,5 +17,5 @@ namespace Super.Paula.Application.Administration.Events
 
         bool Activated)
 
-        : EventBase("event-organization-creation");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Administration/Events/OrganizationDeletionEvent.cs
+++ b/src/application/Transport.Contract/Administration/Events/OrganizationDeletionEvent.cs
@@ -13,5 +13,5 @@ namespace Super.Paula.Application.Administration.Events
         [UniqueName]
         string UniqueName)
 
-        : EventBase("event-organization-deletion");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Administration/Events/OrganizationUpdateEvent.cs
+++ b/src/application/Transport.Contract/Administration/Events/OrganizationUpdateEvent.cs
@@ -17,5 +17,5 @@ namespace Super.Paula.Application.Administration.Events
 
         bool Activated)
 
-        : EventBase("event-organization-update");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Auditing/Continuations/CreateBusinessObjectInspectionAuditRecordContinuation.cs
+++ b/src/application/Transport.Contract/Auditing/Continuations/CreateBusinessObjectInspectionAuditRecordContinuation.cs
@@ -39,5 +39,5 @@ namespace Super.Paula.Application.Auditing.Continuations
         [Milliseconds]
         int AuditTime)
 
-        : ContinuationBase("create-business-object-inspection-audit-record");
+        : ContinuationBase();
 }

--- a/src/application/Transport.Contract/Auditing/Events/BusinessObjectInspectionAuditScheduleEvent.cs
+++ b/src/application/Transport.Contract/Auditing/Events/BusinessObjectInspectionAuditScheduleEvent.cs
@@ -21,5 +21,5 @@ namespace Super.Paula.Application.Auditing.Events
         [Milliseconds]
         int Threshold)
 
-        : EventBase("event-business-object-inspection-audit-schedule");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Guidelines/Events/InspectionDeletionEvent.cs
+++ b/src/application/Transport.Contract/Guidelines/Events/InspectionDeletionEvent.cs
@@ -13,5 +13,5 @@ namespace Super.Paula.Application.Guidelines.Events
         [KebabCase]
         string UniqueName)
 
-        : EventBase("event-inspection-deletion");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Guidelines/Events/InspectionEvent.cs
+++ b/src/application/Transport.Contract/Guidelines/Events/InspectionEvent.cs
@@ -21,6 +21,6 @@ namespace Super.Paula.Application.Guidelines.Events
 
         bool Activated)
 
-        : EventBase("event-inspection");
+        : EventBase();
 
 }

--- a/src/application/Transport.Contract/Inventory/Events/BusinessObjectDeletionEvent.cs
+++ b/src/application/Transport.Contract/Inventory/Events/BusinessObjectDeletionEvent.cs
@@ -13,5 +13,5 @@ namespace Super.Paula.Application.Inventory.Events
         [KebabCase]
         string UniqueName)
 
-        : EventBase("event-business-object-deletion");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Inventory/Events/BusinessObjectEvent.cs
+++ b/src/application/Transport.Contract/Inventory/Events/BusinessObjectEvent.cs
@@ -15,5 +15,5 @@ namespace Super.Paula.Application.Inventory.Events
         [StringLength(140)]
         string DisplayName)
 
-        : EventBase("event-business-object");
+        : EventBase();
 }

--- a/src/application/Transport.Contract/Inventory/Events/BusinessObjectInspectorEvent.cs
+++ b/src/application/Transport.Contract/Inventory/Events/BusinessObjectInspectorEvent.cs
@@ -26,5 +26,5 @@ namespace Super.Paula.Application.Inventory.Events
         [UniqueName]
         string OldInspector)
 
-        : EventBase("event-business-object-inspector");
+        : EventBase();
 }

--- a/src/application/Transport/_Continuations.cs
+++ b/src/application/Transport/_Continuations.cs
@@ -20,19 +20,19 @@ namespace Super.Paula.Application
 
         private static IContinuationRegistry ConfigureTransportAdministration(this IContinuationRegistry continuationRegistry)
         {
-            continuationRegistry.Register<CreateInspectorContinuation, InspectorContinuationHandler>("create-inspector");
+            continuationRegistry.Register<CreateInspectorContinuation, InspectorContinuationHandler>();
 
-            continuationRegistry.Register<CreateIdentityInspectorContinuation, IdentityInspectorContinuationHandler>("create-identity-inspector");
-            continuationRegistry.Register<DeleteIdentityInspectorContinuation, IdentityInspectorContinuationHandler>("delete-identity-inspector");
-            continuationRegistry.Register<ActivateIdentityInspectorContinuation, IdentityInspectorContinuationHandler>("activate-identity-inspector");
-            continuationRegistry.Register<DeactivateIdentityInspectorContinuation, IdentityInspectorContinuationHandler>("deactivate-identity-inspector");
+            continuationRegistry.Register<CreateIdentityInspectorContinuation, IdentityInspectorContinuationHandler>();
+            continuationRegistry.Register<DeleteIdentityInspectorContinuation, IdentityInspectorContinuationHandler>();
+            continuationRegistry.Register<ActivateIdentityInspectorContinuation, IdentityInspectorContinuationHandler>();
+            continuationRegistry.Register<DeactivateIdentityInspectorContinuation, IdentityInspectorContinuationHandler>();
 
             return continuationRegistry;
         }
 
         private static IContinuationRegistry ConfigureTransportAuditing(this IContinuationRegistry continuationRegistry)
         {
-            continuationRegistry.Register<CreateBusinessObjectInspectionAuditRecordContinuation, BusinessObjectInspectionAuditRecordContinuationHandler>("create-business-object-inspection-audit-record");
+            continuationRegistry.Register<CreateBusinessObjectInspectionAuditRecordContinuation, BusinessObjectInspectionAuditRecordContinuationHandler>();
 
             return continuationRegistry;
         }

--- a/src/application/Transport/_EventTypes.cs
+++ b/src/application/Transport/_EventTypes.cs
@@ -22,34 +22,34 @@ namespace Super.Paula.Application
 
         private static IEventTypeRegistry ConfigureTransportAdministration(this IEventTypeRegistry eventTypeRegistry)
         {
-            eventTypeRegistry.Register<OrganizationCreationEvent>("event-organization-creation");
-            eventTypeRegistry.Register<OrganizationDeletionEvent>("event-organization-deletion");
-            eventTypeRegistry.Register<OrganizationUpdateEvent>("event-organization-update");
-            eventTypeRegistry.Register<InspectorBusinessObjectEvent>("event-inspector-business-object");
+            eventTypeRegistry.Register<OrganizationCreationEvent>();
+            eventTypeRegistry.Register<OrganizationDeletionEvent>();
+            eventTypeRegistry.Register<OrganizationUpdateEvent>();
+            eventTypeRegistry.Register<InspectorBusinessObjectEvent>();
 
             return eventTypeRegistry;
         }
 
         private static IEventTypeRegistry ConfigureTransportAuditing(this IEventTypeRegistry eventTypeRegistry)
         {
-            eventTypeRegistry.Register<BusinessObjectInspectionAuditScheduleEvent>("event-business-object-inspection-audit-schedule");
+            eventTypeRegistry.Register<BusinessObjectInspectionAuditScheduleEvent>();
 
             return eventTypeRegistry;
         }
 
         private static IEventTypeRegistry ConfigureTransportGuidlines(this IEventTypeRegistry eventTypeRegistry)
         {
-            eventTypeRegistry.Register<InspectionDeletionEvent>("event-inspection-deletion");
-            eventTypeRegistry.Register<InspectionEvent>("event-inspection");
+            eventTypeRegistry.Register<InspectionDeletionEvent>();
+            eventTypeRegistry.Register<InspectionEvent>();
 
             return eventTypeRegistry;
         }
 
         private static IEventTypeRegistry ConfigureTransportInventory(this IEventTypeRegistry eventTypeRegistry)
         {
-            eventTypeRegistry.Register<BusinessObjectInspectorEvent>("event-business-object-inspector");
-            eventTypeRegistry.Register<BusinessObjectEvent>("event-business-object");
-            eventTypeRegistry.Register<BusinessObjectDeletionEvent>("event-business-object-deletion");
+            eventTypeRegistry.Register<BusinessObjectInspectorEvent>();
+            eventTypeRegistry.Register<BusinessObjectEvent>();
+            eventTypeRegistry.Register<BusinessObjectDeletionEvent>();
 
             return eventTypeRegistry;
         }


### PR DESCRIPTION
Currently, continuation and event names are hard coded in different places of the back end. This is not ideal in, as it can cause unwanted errors by misspelling the same event at different places.

The hard coded names are always kebab case in the moment.

The goal of this feature is to implement a small component that will convert a type name into kebab case. This component will be used to generate the continuation names and the event names automatically. 