### PR TITLE
Route grouping

### DIFF
--- a/src/application/Endpoints/Administration/AuthorizationEndpoints.cs
+++ b/src/application/Endpoints/Administration/AuthorizationEndpoints.cs
@@ -9,20 +9,24 @@ namespace Super.Paula.Application.Administration
     {
         public static IEndpointRouteBuilder MapAuthorization(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Organization Inspectors",
                 "/organizations/{organization}/inspectors/{inspector}",
                 ("/authorize", Authorize),
                 ("/impersonate", Impersonate));
 
-            endpoints.MapCommands(
-                "/inspector/current",
+            endpoints.MapRestResouceCommands(
+                "Current Inspector",
+                "/inspector/me",
                 ("/unmask", Unmask));
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Organizations",
                 "/organizations/{organization}",
                 ("/initialize", Initialize));
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Organizations",
                 "/organizations",
                 ("/register", Register));
 

--- a/src/application/Endpoints/Administration/InspectorAvatarEndpoints.cs
+++ b/src/application/Endpoints/Administration/InspectorAvatarEndpoints.cs
@@ -13,11 +13,13 @@ namespace Super.Paula.Application.Administration
     {
         public static IEndpointRouteBuilder MapInspectorAvatar(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapResource(
+            endpoints.MapRestResource(
+                "Inspector Avatar",
                 "/inspectors/{inspector}/avatar",
                 Get, null, null);
 
-            endpoints.MapResource(
+            endpoints.MapRestResource(
+                "Current Inspector",
                 "/inspectors/me/avatar",
                 GetMe,
                 PutMe,

--- a/src/application/Endpoints/Administration/InspectorEndpoints.cs
+++ b/src/application/Endpoints/Administration/InspectorEndpoints.cs
@@ -10,29 +10,34 @@ namespace Super.Paula.Application.Administration
     {
         public static IEndpointRouteBuilder MapInspector(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Inspectors",
                 "/inspectors",
-                "/inspectors/{inspector}",
+                "/{inspector}",
                 Get,
                 GetAll,
                 Create,
                 Replace,
                 Delete);
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Inspectors",
                 "/inspectors/{inspector}",
                 ("/activate", Activate),
                 ("/deactivate", Deactivate));
 
-            endpoints.MapQueries(
+            endpoints.MapRestCollectionQueries(
+                "Organization Inspectors",
                 "/organizations",
                 ("/{organization}/inspectors", GetAllForOrganization));
 
-            endpoints.MapQueries(
+            endpoints.MapRestCollectionQueries(
+                "Current Inspector",
                 "/inspectors",
                 ("/me", GetCurrent));
 
-            endpoints.MapQueries(
+            endpoints.MapRestCollectionQueries(
+                "Identity Inspectors",
                 "/identities",
                 ("/{identity}/inspectors", GetAllForIdentity));
 

--- a/src/application/Endpoints/Administration/OrganizationEndpoints.cs
+++ b/src/application/Endpoints/Administration/OrganizationEndpoints.cs
@@ -10,16 +10,18 @@ namespace Super.Paula.Application.Administration
     {
         public static IEndpointRouteBuilder MapOrganization(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Organizations",
                 "/organizations",
-                "/organizations/{organization}",
+                "/{organization}",
                 Get,
                 GetAll,
                 Create,
                 Replace,
                 Delete);
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Organizations",
                 "/organizations/{organization}",
                 ("/activate", Activate),
                 ("/deactivate", Deactivate));

--- a/src/application/Endpoints/Auditing/BusinessObjectInspectionAuditRecordEndpoints.cs
+++ b/src/application/Endpoints/Auditing/BusinessObjectInspectionAuditRecordEndpoints.cs
@@ -11,16 +11,25 @@ namespace Super.Paula.Application.Auditing
     {
         public static IEndpointRouteBuilder MapBusinessObjectInspectionAuditRecord(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Business Object Inspection Audit Records",
                 "/business-objects/{businessObject}/inspection-audit-records",
-                "/business-objects/{businessObject}/inspections/{inspection}/audit-records/{date}/{time}",
-                Get,
+                string.Empty,
+                null,
                 GetAllForBusinessObject,
                 Create,
+                null,
+                null);
+
+            endpoints.MapRestResource(
+                "Business Object Inspection Audit Records",
+                "/business-objects/{businessObject}/inspections/{inspection}/audit-records/{date}/{time}",
+                Get,
                 Replace,
                 Delete);
 
-            endpoints.MapQueries(
+            endpoints.MapRestCollectionQueries(
+                "Inspection Audit Records",
                 "/inspection-audit-records",
                 ("", GetAll),
                 ("/search", Search));

--- a/src/application/Endpoints/Auditing/BusinessObjectInspectionEndpoints.cs
+++ b/src/application/Endpoints/Auditing/BusinessObjectInspectionEndpoints.cs
@@ -10,16 +10,18 @@ namespace Super.Paula.Application.Auditing
     {
         public static IEndpointRouteBuilder MapBusinessObjectInspection(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Business Object Inspections",
                 "/business-objects/{businessObject}/inspections",
-                "/business-objects/{businessObject}/inspections/{inspection}",
+                "/{inspection}",
                 Get,
                 GetAllForBusinessObject,
                 Create,
                 Replace,
                 Delete);
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Business Object Inspections",
                  "/business-objects/{businessObject}/inspections/{inspection}",
                  ("/replace-audit-schedule", ReplaceAuditSchedule),
                  ("/create-audit-schedule-omission", CreateAuditOmission),
@@ -32,18 +34,18 @@ namespace Super.Paula.Application.Auditing
 
         private static Delegate Get =>
             [Authorize("AuditingLimited")]
-        (IBusinessObjectInspectionHandler handler, string businessObject, string inspection)
+            (IBusinessObjectInspectionHandler handler, string businessObject, string inspection)
                 => handler.GetAsync(businessObject, inspection);
 
         private static Delegate GetAllForBusinessObject =>
             [Authorize("AuditingLimited")]
-        (IBusinessObjectInspectionHandler handler,
+            (IBusinessObjectInspectionHandler handler,
                 string businessObject)
                 => handler.GetAllForBusinessObject(businessObject);
 
         private static Delegate Create =>
             [Authorize("ManagementFull")]
-        (IBusinessObjectInspectionHandler handler,
+            (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 BusinessObjectInspectionRequest request)
 
@@ -51,7 +53,7 @@ namespace Super.Paula.Application.Auditing
 
         private static Delegate Replace =>
             [Authorize("ManagementFull")]
-        (IBusinessObjectInspectionHandler handler,
+            (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,
                 BusinessObjectInspectionRequest request)
@@ -60,7 +62,7 @@ namespace Super.Paula.Application.Auditing
 
         private static Delegate Delete =>
             [Authorize("ManagementFull")]
-        (IBusinessObjectInspectionHandler handler,
+            (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,
                 [FromHeader(Name = "If-Match")] string etag)
@@ -68,6 +70,7 @@ namespace Super.Paula.Application.Auditing
                 => handler.DeleteAsync(businessObject, inspection, etag);
 
         private static Delegate ReplaceAuditSchedule =>
+            [Authorize("Maintainance")]
             (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,
@@ -76,6 +79,7 @@ namespace Super.Paula.Application.Auditing
                 => handler.ReplaceAuditScheduleAsync(businessObject, inspection, request);
 
         private static Delegate CreateAuditOmission =>
+            [Authorize("Maintainance")]
             (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,
@@ -84,6 +88,7 @@ namespace Super.Paula.Application.Auditing
                 => handler.CreateAuditOmissionAsync(businessObject, inspection, request);
 
         private static Delegate CreateAudit =>
+            [Authorize("AuditingLimited")]
             (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,
@@ -92,6 +97,7 @@ namespace Super.Paula.Application.Auditing
                 => handler.CreateAuditAsync(businessObject, inspection, request);
 
         private static Delegate ReplaceAudit =>
+            [Authorize("AuditingLimited")]
             (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,
@@ -100,6 +106,7 @@ namespace Super.Paula.Application.Auditing
                 => handler.ReplaceAuditAsync(businessObject, inspection, request);
 
         private static Delegate ReplaceAuditAnnotation =>
+            [Authorize("AuditingLimited")]
             (IBusinessObjectInspectionHandler handler,
                 string businessObject,
                 string inspection,

--- a/src/application/Endpoints/Auth/AuthenticationEndpoints.cs
+++ b/src/application/Endpoints/Auth/AuthenticationEndpoints.cs
@@ -10,17 +10,20 @@ namespace Super.Paula.Application.Auth
     {
         public static IEndpointRouteBuilder MapAuthentication(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Identities",
                 "/identities",
                 ("/register", Register));
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Identities",
                 "/identities/{identity}",
                 ("/sign-in", SignIn),
                 ("/reset", Reset));
 
-            endpoints.MapCommands(
-                "/identities/current",
+            endpoints.MapRestResouceCommands(
+                "Current Identity",
+                "/identities/me",
                 ("/sign-out", SignOut),
                 ("/change-secret", ChangeSecret));
 

--- a/src/application/Endpoints/Auth/IdentityEndpoints.cs
+++ b/src/application/Endpoints/Auth/IdentityEndpoints.cs
@@ -10,9 +10,10 @@ namespace Super.Paula.Application.Auth
     {
         public static IEndpointRouteBuilder MapIdentity(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Identities",
                 "/identities",
-                "/identities/{identity}",
+                "/{identity}",
                 Get,
                 GetAll,
                 Create,

--- a/src/application/Endpoints/Communication/NotificationEndpoints.cs
+++ b/src/application/Endpoints/Communication/NotificationEndpoints.cs
@@ -10,16 +10,18 @@ namespace Super.Paula.Application.Communication
     {
         public static IEndpointRouteBuilder MapNotification(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Inspector Notifications",
                 "/inspectors/{inspector}/notifications",
-                "/inspectors/{inspector}/notifications/{date}/{time}",
+                "/{date}/{time}",
                 Get,
                 GetAllForInspector,
                 Create,
                 Replace,
                 Delete);
 
-            endpoints.MapQueries(
+            endpoints.MapRestCollectionQueries(
+                "Notifications",
                 "/notifications",
                 ("", GetAll));
 

--- a/src/application/Endpoints/Endpoints.csproj
+++ b/src/application/Endpoints/Endpoints.csproj
@@ -12,6 +12,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0-preview.6.22330.3" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Streaming.Contract\Streaming.Contract.csproj" />
 		<ProjectReference Include="..\Transport.Contract\Transport.Contract.csproj" />
 	</ItemGroup>

--- a/src/application/Endpoints/Guidelines/InspectionEndpoints.cs
+++ b/src/application/Endpoints/Guidelines/InspectionEndpoints.cs
@@ -10,7 +10,8 @@ namespace Super.Paula.Application.Guidelines
     {
         public static IEndpointRouteBuilder MapInspection(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Inspections",
                 "/inspections",
                 "/inspections/{inspection}",
                 Get,
@@ -19,7 +20,8 @@ namespace Super.Paula.Application.Guidelines
                 Replace,
                 Delete);
 
-            endpoints.MapCommands(
+            endpoints.MapRestResouceCommands(
+                "Inspections",
                 "/inspections/{inspection}",
                 ("/activate", Activate),
                 ("/deactivate", Deactivate));

--- a/src/application/Endpoints/Inventory/BusinessObjectEndpoints.cs
+++ b/src/application/Endpoints/Inventory/BusinessObjectEndpoints.cs
@@ -11,16 +11,18 @@ namespace Super.Paula.Application.Inventory
     {
         public static IEndpointRouteBuilder MapBusinessObject(this IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapCollection(
+            endpoints.MapRestCollection(
+                "Business Objects",
                 "/business-objects",
-                "/business-objects/{businessObject}",
+                "/{businessObject}",
                 Get,
                 GetAll,
                 Create,
                 Replace,
                 Delete);
 
-            endpoints.MapQueries(
+            endpoints.MapRestCollectionQueries(
+                "Business Objects",
                 "/business-objects",
                 ("/search", Search));
 

--- a/src/application/Endpoints/_Endpoints.cs
+++ b/src/application/Endpoints/_Endpoints.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -8,6 +9,101 @@ namespace Super.Paula.Application
     [SuppressMessage("Style", "IDE1006")]
     public static class _Endpoints
     {
+        public const string RouteSeparator = "/";
+
+        public static IEndpointRouteBuilder MapRestCollection(this IEndpointRouteBuilder endpoints,
+            string tag,
+            string collection,
+            string resource,
+            Delegate? get,
+            Delegate? getAll,
+            Delegate? create,
+            Delegate? replace,
+            Delegate? delete)
+        {
+            var collectionGroup = endpoints
+                .MapGroup(collection)
+                .WithTags(tag);
+
+            if (getAll != null)
+                collectionGroup.MapGet(RouteSeparator, getAll);
+
+            if (create != null)
+                collectionGroup.MapPost(RouteSeparator, create);
+
+            var resourceGroup = collectionGroup.MapGroup(resource);
+
+            if (get != null)
+                resourceGroup.MapGet(RouteSeparator, get);
+
+            if (replace != null)
+                resourceGroup.MapPut(RouteSeparator, replace);
+
+            if (delete != null)
+                resourceGroup.MapDelete(RouteSeparator, delete);
+
+            return endpoints;
+        }
+
+        public static IEndpointRouteBuilder MapRestResource(this IEndpointRouteBuilder endpoints,
+            string tag,
+            string resource,
+            Delegate? get,
+            Delegate? replace,
+            Delegate? delete)
+        {
+            var resourceGroup = endpoints.MapGroup(resource);
+
+            if (tag != null)
+                resourceGroup.WithTags(tag);
+
+            if (get != null)
+                resourceGroup.MapGet(RouteSeparator, get);
+
+            if (replace != null)
+                resourceGroup.MapPut(RouteSeparator, replace);
+
+            if (delete != null)
+                resourceGroup.MapDelete(RouteSeparator, delete);
+
+            return endpoints;
+        }
+
+        public static IEndpointRouteBuilder MapRestCollectionQueries(this IEndpointRouteBuilder endpoints,
+            string tag,
+            string collection,
+            params (string, Delegate)[] queries)
+        {
+            var collectionGroup = endpoints
+                .MapGroup(collection)
+                .WithTags(tag);
+
+            foreach (var query in queries)
+            {
+                collectionGroup.MapGet($"{query.Item1}", query.Item2);
+            }
+
+            return endpoints;
+        }
+
+        public static IEndpointRouteBuilder MapRestResouceCommands(this IEndpointRouteBuilder endpoints,
+            string tag,
+            string resource,
+            params (string, Delegate)[] posts)
+        {
+            var resourceGroup = endpoints
+                .MapGroup(resource)
+                .WithTags(tag);
+
+            foreach (var post in posts)
+            {
+                resourceGroup.MapPost($"{post.Item1}", post.Item2);
+            }
+
+            return endpoints;
+        }
+
+        [Obsolete]
         public static IEndpointRouteBuilder MapCollection(this IEndpointRouteBuilder endpoints,
             string collection,
             string collectionResource,
@@ -35,6 +131,7 @@ namespace Super.Paula.Application
             return endpoints;
         }
 
+        [Obsolete]
         public static IEndpointRouteBuilder MapResource(this IEndpointRouteBuilder endpoints,
             string collection,
             Delegate? get,
@@ -53,6 +150,7 @@ namespace Super.Paula.Application
             return endpoints;
         }
 
+        [Obsolete]
         public static IEndpointRouteBuilder MapQueries(this IEndpointRouteBuilder endpoints,
             string path,
             params (string, Delegate)[] queries)
@@ -65,6 +163,7 @@ namespace Super.Paula.Application
             return endpoints;
         }
 
+        [Obsolete]
         public static IEndpointRouteBuilder MapCommands(this IEndpointRouteBuilder endpoints,
             string path,
             params (string, Delegate)[] posts)

--- a/src/application/Transport.Client/Administration/AuthorizationHandler.cs
+++ b/src/application/Transport.Client/Administration/AuthorizationHandler.cs
@@ -41,7 +41,7 @@ namespace Super.Paula.Client.Administration
 
         public async ValueTask<string> StopImpersonationAsync()
         {
-            var responseMessage = await _httpClient.PostAsync("inspectors/current/unmask", null);
+            var responseMessage = await _httpClient.PostAsync("inspectors/me/unmask", null);
 
             responseMessage.RuleOutProblems();
             responseMessage.EnsureSuccessStatusCode();

--- a/src/application/Transport.Client/Auth/AuthenticationHandler.cs
+++ b/src/application/Transport.Client/Auth/AuthenticationHandler.cs
@@ -25,7 +25,7 @@ namespace Super.Paula.Client.Auth
 
         public async ValueTask ChangeSecretAsync(ChangeIdentitySecretRequest request)
         {
-            var responseMessage = await _httpClient.PostAsJsonAsync("identities/current/change-secret", request);
+            var responseMessage = await _httpClient.PostAsJsonAsync("identities/me/change-secret", request);
 
             responseMessage.RuleOutProblems();
             responseMessage.EnsureSuccessStatusCode();
@@ -53,7 +53,7 @@ namespace Super.Paula.Client.Auth
         {
             try
             {
-                var responseMessage = await _httpClient.PostAsync("identities/current/sign-out", null);
+                var responseMessage = await _httpClient.PostAsync("identities/me/sign-out", null);
 
                 responseMessage.RuleOutProblems();
                 responseMessage.EnsureSuccessStatusCode();

--- a/src/server/ServerApp/Properties/launchSettings.json
+++ b/src/server/ServerApp/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Super.Paula.Server": {
       "commandName": "Project",
+      "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/server/ServerApp/Startup.cs
+++ b/src/server/ServerApp/Startup.cs
@@ -94,7 +94,7 @@ namespace Super.Paula
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapServer();
-                endpoints.MapGet("", () => "It works!");
+                endpoints.MapGet("", () => "It works!").WithTags("Health");
             });
 
             app.ConfigureEvents();

--- a/src/server/ServerApp/Swagger/ConfigureSwaggerGenOptions.cs
+++ b/src/server/ServerApp/Swagger/ConfigureSwaggerGenOptions.cs
@@ -18,6 +18,8 @@ namespace Super.Paula.Swagger
 
             options.OperationFilter<AuthorizationOperationFilter>();
             options.SwaggerDoc("v1", new() { Title = "Super.Paula.Server", Version = "v1" });
+            
+            options.OrderActionsBy(x => x.RelativePath);
         }
     }
 }


### PR DESCRIPTION
Endpoint groups are a new feature of .NET 7. The groups allow easier definition of OpenAPI specification for Minimal API endpoints. The usage of those definitions will lead to a clearer OpenAPI and Swagger presentation.

The goal of the feature is to refactor all endpoints in respect to endpoint groups and OpenAPI tags.