### PR TITLE
Authorization policy clean up

### DIFF
--- a/src/application/Endpoints/Administration/AuthorizationEndpoints.cs
+++ b/src/application/Endpoints/Administration/AuthorizationEndpoints.cs
@@ -56,7 +56,7 @@ namespace Super.Paula.Application.Administration
                     => handler.StartImpersonationAsync(organization, inspector);
 
         private static Delegate Unmask =>
-            [Authorize("Maintainance")]
+            [Authorize("Impersonation")]
             (IAuthorizationHandler handler)
                 => handler.StopImpersonationAsync();
     }

--- a/src/application/Security.Contract/Authorization/ClaimsPrincipalExtensions.cs
+++ b/src/application/Security.Contract/Authorization/ClaimsPrincipalExtensions.cs
@@ -70,7 +70,7 @@ namespace Super.Paula.Authorization
         public static bool HasAuthorization(this ClaimsPrincipal principal, string authorization)
             => principal.HasClaim("Authorization", authorization);
 
-        public static bool HasAuthorizations(this ClaimsPrincipal principal, params string[] authorizations)
+        public static bool HasAnyAuthorization(this ClaimsPrincipal principal, params string[] authorizations)
             => principal.FindAll("Authorization")
                 .Where(x => authorizations.Contains(x.Value))
                 .Any(x => !principal.FindAll("AuthorizationFilter").Any() ||

--- a/src/application/Security/Authorization/AnyAuthorizationClaimHandler.cs
+++ b/src/application/Security/Authorization/AnyAuthorizationClaimHandler.cs
@@ -8,7 +8,7 @@ namespace Super.Paula.Authorization
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, AnyAuthorizationClaimRequirement requirement)
         {
             var isAuthorized = context.User
-                .HasAuthorizations(requirement.Authorizations);
+                .HasAnyAuthorization(requirement.Authorizations);
 
             if (isAuthorized)
             {

--- a/src/application/Security/Authorization/IdentityClaimResourceHandler.cs
+++ b/src/application/Security/Authorization/IdentityClaimResourceHandler.cs
@@ -8,7 +8,7 @@ namespace Super.Paula.Authorization
     {
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, IdentityClaimResourceRequirement requirement)
         {
-            var isAuthorized = context.User.HasAuthorizations(requirement.Authorizations);
+            var isAuthorized = context.User.HasAnyAuthorization(requirement.Authorizations);
 
             if (isAuthorized)
             {

--- a/src/application/Security/Authorization/InspectorClaimResourceHandler.cs
+++ b/src/application/Security/Authorization/InspectorClaimResourceHandler.cs
@@ -8,7 +8,7 @@ namespace Super.Paula.Authorization
     {
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, InspectorClaimResourceRequirement requirement)
         {
-            var isAuthorized = context.User.HasAuthorizations(requirement.Authorizations);
+            var isAuthorized = context.User.HasAnyAuthorization(requirement.Authorizations);
 
             if (isAuthorized)
             {

--- a/src/application/Security/Authorization/PaulaAuthorizationPolicyProvider.cs
+++ b/src/application/Security/Authorization/PaulaAuthorizationPolicyProvider.cs
@@ -24,7 +24,6 @@ namespace Super.Paula.Authorization
                     "AuditingLimited" => _Policies.AuditingLimitedPolicy,
 
                     "Impersonation" => _Policies.ImpersonationPolicy,
-                    "Streaming" => _Policies.StreamingPolicy,
                     _ => null
                 });
     }

--- a/src/application/Security/Authorization/_Policies.cs
+++ b/src/application/Security/Authorization/_Policies.cs
@@ -37,11 +37,6 @@ namespace Super.Paula.Authorization
                 .AddRequirements(new AnyAuthorizationClaimRequirement("Impersonator"))
                 .Build();
 
-        public static AuthorizationPolicy StreamingPolicy =>
-            new AuthorizationPolicyBuilder()
-                .AddRequirements(new AnyAuthorizationClaimRequirement("Streamer"))
-                .Build();
-
         public static AuthorizationPolicy ManagementReadPolicy =>
             new AuthorizationPolicyBuilder()
                 .AddRequirements(new AnyAuthorizationClaimRequirement("Chief", "Observer"))


### PR DESCRIPTION
Some minor changes in the policy description for the authorization must be implemented.

The `streaming` policy should be removed. 
Unmasking an `impersonation` should only be allowed for `impersonators`.